### PR TITLE
Ensure x86-64 binary is always built even on arm64 systems

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -11,8 +11,19 @@ if [ "$(uname)" = "Linux" ]; then
 fi
 LINKFLAGS="-X main.Version=$VERSION"
 LINKFLAGS="-X main.GitCommit=$COMMIT $LINKFLAGS"
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
-if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
-    GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
-    GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
+if [ "$ARCH" == "amd64" ]; then
+  CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/backup-restore-operator
+  if [ "$CROSS" = "true" ]; then
+      GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
+      GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
+  fi
+else
+  GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator"
+  CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o "bin/backup-restore-operator$SUFFIX"
+    if [ "$CROSS" = "true" ]; then
+        GOARCH=amd64 GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-darwin
+        GOOS=darwin go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-darwin$SUFFIX"
+        GOARCH=amd64 GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/backup-restore-operator-windows
+        GOOS=windows go build -ldflags "$LINKFLAGS" -o "bin/backup-restore-operator-windows$SUFFIX"
+    fi
 fi

--- a/scripts/package
+++ b/scripts/package
@@ -6,7 +6,7 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p dist/artifacts
-cp bin/backup-restore-operator dist/artifacts/backup-restore-operator${SUFFIX}
+cp bin/backup-restore-operator-* dist/artifacts/
 
 IMAGE=${REPO}/backup-restore-operator:${TAG}
 DOCKERFILE=package/Dockerfile


### PR DESCRIPTION
Currently on an arm64 based system the binary will be arm64.
Then when the package script is run, it copies that arm64 binary into the image.
Totally fine when you build an arm64 container image, however packing arm64 binary into an amd64 image is not.

initially thought package script needed changes, however I think the `package/Dockerfile.{$ARCH}` files will address that. However I only see the base docker file in that folder currently, so unsure on that aspect.